### PR TITLE
debian/totem.install: Update install path for appdata XML file

### DIFF
--- a/debian/totem.install
+++ b/debian/totem.install
@@ -1,5 +1,5 @@
 usr/bin
 usr/lib/*/nautilus
 usr/share/applications
-usr/share/appdata/org.gnome.Totem.appdata.xml
+usr/share/metainfo/org.gnome.Totem.appdata.xml
 usr/share/dbus-1/services/


### PR DESCRIPTION
These files are now being installed under /usr/share/metainfo, as
per update to the relevant M4 macro, instead of to the old (and now
deprecated) /usr/share/appdata location.

https://phabricator.endlessm.com/T21852